### PR TITLE
Remove size constraints on input data

### DIFF
--- a/src/exe/mick/mick.cpp
+++ b/src/exe/mick/mick.cpp
@@ -90,14 +90,16 @@ int main(int argc, char** argv)
 		if (!exists(input))
 			return help(options, "Please specify an input file that exists!");
 
-		string output = result["output"].as<string>();
 		string key = fmt::format("{}/{}.pk", key_path, id);
+		std::ifstream istream(input, std::ifstream::binary);
+		string output = result["output"].as<string>();
+
 		if (output.empty())
-			return mcleece::actions::encrypt(key, input, std::cout);
+			return mcleece::actions::encrypt(key, istream, std::cout);
 		else
 		{
 			std::ofstream f(output, std::ofstream::binary);
-			return mcleece::actions::encrypt(key, input, f);
+			return mcleece::actions::encrypt(key, istream, f);
 		}
 	}
 
@@ -109,15 +111,17 @@ int main(int argc, char** argv)
 		if (!exists(input))
 			return help(options, "Please specify an input file that exists!");
 
-		string pw = get_pw();
-		string output = result["output"].as<string>();
 		string key = fmt::format("{}/{}.sk", key_path, id);
+		string pw = get_pw();
+		std::ifstream istream(input, std::ifstream::binary);
+		string output = result["output"].as<string>();
+
 		if (output.empty())
-			return mcleece::actions::decrypt(key, pw, input, std::cout);
+			return mcleece::actions::decrypt(key, pw, istream, std::cout);
 		else
 		{
 			std::ofstream f(output, std::ofstream::binary);
-			return mcleece::actions::decrypt(key, pw, input, f);
+			return mcleece::actions::decrypt(key, pw, istream, f);
 		}
 	}
 

--- a/src/exe/mick/mick.cpp
+++ b/src/exe/mick/mick.cpp
@@ -91,14 +91,14 @@ int main(int argc, char** argv)
 			return help(options, "Please specify an input file that exists!");
 
 		string key = fmt::format("{}/{}.pk", key_path, id);
-		std::ifstream istream(input, std::ifstream::binary);
+		std::ifstream istream(input, std::ios::binary);
 		string output = result["output"].as<string>();
 
 		if (output.empty())
 			return mcleece::actions::encrypt(key, istream, std::cout);
 		else
 		{
-			std::ofstream f(output, std::ofstream::binary);
+			std::ofstream f(output, std::ios::binary);
 			return mcleece::actions::encrypt(key, istream, f);
 		}
 	}
@@ -113,14 +113,14 @@ int main(int argc, char** argv)
 
 		string key = fmt::format("{}/{}.sk", key_path, id);
 		string pw = get_pw();
-		std::ifstream istream(input, std::ifstream::binary);
+		std::ifstream istream(input, std::ios::binary);
 		string output = result["output"].as<string>();
 
 		if (output.empty())
 			return mcleece::actions::decrypt(key, pw, istream, std::cout);
 		else
 		{
-			std::ofstream f(output, std::ofstream::binary);
+			std::ofstream f(output, std::ios::binary);
 			return mcleece::actions::decrypt(key, pw, istream, f);
 		}
 	}

--- a/src/lib/mcleece/actions.h
+++ b/src/lib/mcleece/actions.h
@@ -51,6 +51,8 @@ namespace actions {
 			if (ciphertext.empty())
 				return 200;
 			os << ciphertext;
+
+			++n;
 		}
 		return 0;
 	}
@@ -96,6 +98,8 @@ namespace actions {
 			if (message.empty())
 				return 200;
 			os << message;
+
+			++enc_n;
 		}
 		return 0;
 	}

--- a/src/lib/mcleece/actions.h
+++ b/src/lib/mcleece/actions.h
@@ -4,15 +4,15 @@
 #include "keygen.h"
 #include "message.h"
 
-#include "base64/base.hpp"
 #include "serialize/format.h"
-#include <cstdio>
 #include <string>
 #include <sstream>
 #include <vector>
 
 namespace mcleece {
 namespace actions {
+	const int MAX_MESSAGE_LENGTH = 0x100000;
+
 	int generate_keypair(std::string keypath, std::string pw)
 	{
 		int res = mcleece::generate_keypair(fmt::format("{}.pk", keypath), fmt::format("{}.sk", keypath), pw);
@@ -24,25 +24,34 @@ namespace actions {
 	{
 		mcleece::public_key pubk(keypath);
 
-		std::string data;
-		{
-			std::stringstream ss;
-			ss << is.rdbuf();
-			data = ss.str();
-		}
-		if (data.empty())
+		if (!is)
 			return 104;
 
-		// limit is arbitrarily set at ~50MB. For files larger than that, chunk them up into multiple messages
+		// generate session key. nonce initiallized to a random value, and incremented by 1 for every message
+		// we only use multiple messages when the input is larger than the arbitrary MAX_LENGTH below
 		mcleece::session_key session = mcleece::generate_session_key(pubk);
 		mcleece::nonce n;
 
-		std::string ciphertext = mcleece::encrypt(session, data, n);
-		if (ciphertext.empty())
-			return 200;
-
+		// store session data first
 		std::string sessiontext = mcleece::encode_session(session, n);
-		os << sessiontext << ciphertext;
+		os << sessiontext;
+
+		// encrypt each chunk
+		std::string data;
+		while (is)
+		{
+			data.resize(MAX_MESSAGE_LENGTH);
+			is.read(data.data(), data.size());
+			size_t last_read = is.gcount();
+
+			if (last_read < data.size())
+				data.resize(last_read);
+
+			std::string ciphertext = mcleece::encrypt(session, data, n);
+			if (ciphertext.empty())
+				return 200;
+			os << ciphertext;
+		}
 		return 0;
 	}
 
@@ -51,17 +60,18 @@ namespace actions {
 	{
 		mcleece::private_key secret(keypath, pw);
 
-		std::string data;
-		{
-			std::stringstream ss;
-			ss << is.rdbuf();
-			data = ss.str();
-		}
-		if (data.empty())
+		if (!is)
 			return 104;
 
+		std::string data;
+		size_t last_read;
+
 		// extract the session from the front of the input
-		if (data.size() < mcleece::encoded_session_size())
+		data.resize(mcleece::encoded_session_size());
+		is.read(data.data(), data.size());
+		last_read = is.gcount();
+
+		if (!is or last_read < data.size())
 			return 110;
 		auto session_nonce = mcleece::decode_session(secret, data.data(), mcleece::encoded_session_size());
 		if (!session_nonce)
@@ -71,13 +81,22 @@ namespace actions {
 		mcleece::nonce& enc_n = session_nonce->second;
 
 		// extract the message bytes
-		std::string rec_ciphertext = data.substr(mcleece::encoded_session_size(), data.size());
+		const int MAX_CIPHERTEXT_LENGTH = MAX_MESSAGE_LENGTH + crypto_secretbox_MACBYTES;
+		while (is)
+		{
+			data.resize(MAX_CIPHERTEXT_LENGTH);
+			is.read(data.data(), data.size());
+			last_read = is.gcount();
 
-		// decrypt the message
-		std::string message = mcleece::decrypt(enc_session, rec_ciphertext, enc_n);
-		if (message.empty())
-			return 120;
-		os << message;
+			if (last_read < data.size())
+				data.resize(last_read);
+
+			// decrypt the message
+			std::string message = mcleece::decrypt(enc_session, data, enc_n);
+			if (message.empty())
+				return 200;
+			os << message;
+		}
 		return 0;
 	}
 }}

--- a/src/lib/mcleece/nonce.h
+++ b/src/lib/mcleece/nonce.h
@@ -39,6 +39,20 @@ public:
 		return _data.size();
 	}
 
+	nonce& operator++()
+	{
+		// could also do this by going <-> an int, but this is probably more straightforward?
+		for (int i = _data.size()-1; i >= 0; --i)
+		{
+			unsigned char temp = _data[i];
+			if (++_data[i] > temp)
+				break; // if no overflow, we're done
+			else if (i == 0)
+				_data = {0};
+		}
+		return *this;
+	}
+
 protected:
 	std::array<unsigned char, SIZE> _data;
 };

--- a/src/lib/mcleece/test/actionsTest.cpp
+++ b/src/lib/mcleece/test/actionsTest.cpp
@@ -5,6 +5,8 @@
 #include "mcleece/message.h"
 
 #include "util/MakeTempDirectory.h"
+
+#include "PicoSHA2/picosha2.h"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -13,6 +15,15 @@
 using std::string;
 using namespace std;
 
+namespace {
+	std::string get_hash(std::string filename)
+	{
+		std::ifstream f(filename, std::ios::binary);
+		std::vector<unsigned char> hash(picosha2::k_digest_size);
+		picosha2::hash256(f, hash.begin(), hash.end());
+		return picosha2::bytes_to_hex_string(hash);
+	}
+}
 
 TEST_CASE( "actionsTest/testDecrypt", "[unit]" )
 {
@@ -64,7 +75,6 @@ TEST_CASE( "messageTest/testEncrypt", "[unit]" )
 	assertEquals( "hello friends", message );
 }
 
-
 TEST_CASE( "actionsTest/testRoundtrip", "[unit]" )
 {
 	MakeTempDirectory tempdir;
@@ -84,6 +94,33 @@ TEST_CASE( "actionsTest/testRoundtrip", "[unit]" )
 	std::stringstream ss;
 	assertEquals(0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", std::ifstream(tempdir.path() / "encrypted_msg"), ss));
 	assertEquals( "hello friends", ss.str() );
+}
+
+TEST_CASE( "actionsTest/testRoundtrip.BigFile", "[unit]" )
+{
+	MakeTempDirectory tempdir;
+
+	TestHelpers::generate_keypair(tempdir.path() / "test");
+
+	{
+		std::ofstream f(tempdir.path() / "bigfile");
+		const unsigned size = 10000000;
+		for (int i = 0; i < size; i+=10)
+			f << "0123456789";
+	}
+
+	{
+		std::ofstream f(tempdir.path() / "encrypted_msg");
+		assertEquals( 0, mcleece::actions::encrypt(tempdir.path() / "test.pk", std::ifstream(tempdir.path() / "bigfile"), f) );
+	}
+
+	{
+		std::ofstream f(tempdir.path() / "decrypted");
+		assertEquals( 0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", std::ifstream(tempdir.path() / "encrypted_msg"), f) );
+	}
+
+	string actual = get_hash(tempdir.path() / "decrypted");
+	assertEquals("d52fcc26b48dbd4d79b125eb0a29b803ade07613c67ac7c6f2751aefef008486", actual);
 }
 
 

--- a/src/lib/mcleece/test/actionsTest.cpp
+++ b/src/lib/mcleece/test/actionsTest.cpp
@@ -33,7 +33,7 @@ TEST_CASE( "actionsTest/testDecrypt", "[unit]" )
 	}
 
 	std::stringstream ss;
-	assertEquals(0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", tempdir.path() / "encrypted_msg", ss));
+	assertEquals(0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", std::ifstream(tempdir.path() / "encrypted_msg"), ss));
 	assertEquals( "hello world", ss.str() );
 }
 
@@ -50,7 +50,7 @@ TEST_CASE( "messageTest/testEncrypt", "[unit]" )
 	}
 
 	std::stringstream ss;
-	assertEquals( 0, mcleece::actions::encrypt(tempdir.path() / "test.pk", tempdir.path() / "helloworld", ss) );
+	assertEquals( 0, mcleece::actions::encrypt(tempdir.path() / "test.pk", std::ifstream(tempdir.path() / "helloworld"), ss) );
 
 	std::string enc_message = ss.str();
 	auto session_nonce = mcleece::decode_session(secret, enc_message);
@@ -78,11 +78,11 @@ TEST_CASE( "actionsTest/testRoundtrip", "[unit]" )
 
 	{
 		std::ofstream f(tempdir.path() / "encrypted_msg");
-		assertEquals( 0, mcleece::actions::encrypt(tempdir.path() / "test.pk", tempdir.path() / "helloworld", f) );
+		assertEquals( 0, mcleece::actions::encrypt(tempdir.path() / "test.pk", std::ifstream(tempdir.path() / "helloworld"), f) );
 	}
 
 	std::stringstream ss;
-	assertEquals(0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", tempdir.path() / "encrypted_msg", ss));
+	assertEquals(0, mcleece::actions::decrypt(tempdir.path() / "test.sk", "password", std::ifstream(tempdir.path() / "encrypted_msg"), ss));
 	assertEquals( "hello friends", ss.str() );
 }
 

--- a/src/third_party_lib/PicoSHA2/LICENSE
+++ b/src/third_party_lib/PicoSHA2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/third_party_lib/PicoSHA2/picosha2.h
+++ b/src/third_party_lib/PicoSHA2/picosha2.h
@@ -1,0 +1,377 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR \
+    1048576  //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <sstream>
+#include <vector>
+#include <fstream>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                          0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                          0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline word_t rotr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+    assert(first + 64 == last);
+    static_cast<void>(last);  // for avoiding unused-variable warning
+    word_t w[64];
+    std::fill(w, w + 64, 0);
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) +
+                          w[i - 16]);
+    }
+
+    word_t a = *message_digest;
+    word_t b = *(message_digest + 1);
+    word_t c = *(message_digest + 2);
+    word_t d = *(message_digest + 3);
+    word_t e = *(message_digest + 4);
+    word_t f = *(message_digest + 5);
+    word_t g = *(message_digest + 6);
+    word_t h = *(message_digest + 7);
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+        word_t temp2 = bsig0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = mask_32bit(d + temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = mask_32bit(temp1 + temp2);
+    }
+    *message_digest += a;
+    *(message_digest + 1) += b;
+    *(message_digest + 2) += c;
+    *(message_digest + 3) += d;
+    *(message_digest + 4) += e;
+    *(message_digest + 5) += f;
+    *(message_digest + 6) += g;
+    *(message_digest + 7) += h;
+    for (std::size_t i = 0; i < 8; ++i) {
+        *(message_digest + i) = mask_32bit(*(message_digest + i));
+    }
+}
+
+}  // namespace detail
+
+template <typename InIter>
+void output_hex(InIter first, InIter last, std::ostream& os) {
+    os.setf(std::ios::hex, std::ios::basefield);
+    while (first != last) {
+        os.width(2);
+        os.fill('0');
+        os << static_cast<unsigned int>(*first);
+        ++first;
+    }
+    os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string& hex_str) {
+    std::ostringstream oss;
+    output_hex(first, last, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer& bytes, std::string& hex_str) {
+    bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter>
+std::string bytes_to_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    bytes_to_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+template <typename InContainer>
+std::string bytes_to_hex_string(const InContainer& bytes) {
+    std::string hex_str;
+    bytes_to_hex_string(bytes, hex_str);
+    return hex_str;
+}
+
+class hash256_one_by_one {
+   public:
+    hash256_one_by_one() { init(); }
+
+    void init() {
+        buffer_.clear();
+        std::fill(data_length_digits_, data_length_digits_ + 4, 0);
+        std::copy(detail::initial_message_digest,
+                  detail::initial_message_digest + 8, h_);
+    }
+
+    template <typename RaIter>
+    void process(RaIter first, RaIter last) {
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+        std::copy(first, last, std::back_inserter(buffer_));
+        std::size_t i = 0;
+        for (; i + 64 <= buffer_.size(); i += 64) {
+            detail::hash256_block(h_, buffer_.begin() + i,
+                                  buffer_.begin() + i + 64);
+        }
+        buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+    }
+
+    void finish() {
+        byte_t temp[64];
+        std::fill(temp, temp + 64, 0);
+        std::size_t remains = buffer_.size();
+        std::copy(buffer_.begin(), buffer_.end(), temp);
+        temp[remains] = 0x80;
+
+        if (remains > 55) {
+            std::fill(temp + remains + 1, temp + 64, 0);
+            detail::hash256_block(h_, temp, temp + 64);
+            std::fill(temp, temp + 64 - 4, 0);
+        } else {
+            std::fill(temp + remains + 1, temp + 64 - 4, 0);
+        }
+
+        write_data_bit_length(&(temp[56]));
+        detail::hash256_block(h_, temp, temp + 64);
+    }
+
+    template <typename OutIter>
+    void get_hash_bytes(OutIter first, OutIter last) const {
+        for (const word_t* iter = h_; iter != h_ + 8; ++iter) {
+            for (std::size_t i = 0; i < 4 && first != last; ++i) {
+                *(first++) = detail::mask_8bit(
+                    static_cast<byte_t>((*iter >> (24 - 8 * i))));
+            }
+        }
+    }
+
+   private:
+    void add_to_data_length(word_t n) {
+        word_t carry = 0;
+        data_length_digits_[0] += n;
+        for (std::size_t i = 0; i < 4; ++i) {
+            data_length_digits_[i] += carry;
+            if (data_length_digits_[i] >= 65536u) {
+                carry = data_length_digits_[i] >> 16;
+                data_length_digits_[i] &= 65535u;
+            } else {
+                break;
+            }
+        }
+    }
+    void write_data_bit_length(byte_t* begin) {
+        word_t data_bit_length_digits[4];
+        std::copy(data_length_digits_, data_length_digits_ + 4,
+                  data_bit_length_digits);
+
+        // convert byte length to bit length (multiply 8 or shift 3 times left)
+        word_t carry = 0;
+        for (std::size_t i = 0; i < 4; ++i) {
+            word_t before_val = data_bit_length_digits[i];
+            data_bit_length_digits[i] <<= 3;
+            data_bit_length_digits[i] |= carry;
+            data_bit_length_digits[i] &= 65535u;
+            carry = (before_val >> (16 - 3)) & 65535u;
+        }
+
+        // write data_bit_length
+        for (int i = 3; i >= 0; --i) {
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+        }
+    }
+    std::vector<byte_t> buffer_;
+    word_t data_length_digits_[4];  // as 64bit integer (16bit x 4 integer)
+    word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one& hasher,
+                                std::string& hex_str) {
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
+    std::string hex_str;
+    get_hash_hex_string(hasher, hex_str);
+    return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+    hash256_one_by_one hasher;
+    // hasher.init();
+    hasher.process(first, last);
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2,
+                  OutIter last2, int buffer_size, std::input_iterator_tag) {
+    std::vector<byte_t> buffer(buffer_size);
+    hash256_one_by_one hasher;
+    // hasher.init();
+    while (first != last) {
+        int size = buffer_size;
+        for (int i = 0; i != buffer_size; ++i, ++first) {
+            if (first == last) {
+                size = i;
+                break;
+            }
+            buffer[i] = *first;
+        }
+        hasher.process(buffer.begin(), buffer.begin() + size);
+    }
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+}
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+    picosha2::impl::hash256_impl(
+        first, last, first2, last2, buffer_size,
+        typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer& dst) {
+    hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer& src, OutIter first, OutIter last) {
+    hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer& src, OutContainer& dst) {
+    hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
+    std::ostringstream oss;
+    output_hex(hashed, hashed + k_digest_size, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InIter>
+std::string hash256_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    hash256_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+inline void hash256_hex_string(const std::string& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+std::string hash256_hex_string(const InContainer& src) {
+    return hash256_hex_string(src.begin(), src.end());
+}
+template<typename OutIter>void hash256(std::ifstream& f, OutIter first, OutIter last){
+    hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first,last);
+
+}
+}// namespace picosha2
+#endif  // PICOSHA2_H


### PR DESCRIPTION
Instead, encode in 1MB chunks, incrementing the nonce (initialized to a random value) for each chunk.

(there are some endianness implications here maybe -- I haven't thought about it *too* hard)