### PR TITLE
Add optional base64 encoding/decoding for ciphertext output/input

### DIFF
--- a/src/exe/mick/mick.cpp
+++ b/src/exe/mick/mick.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 	    ("i,input", "Input file. Required for [encrypt|decrypt]", cxxopts::value<string>()->default_value(""))
 	    ("o,output", "Output file. No value -> stdout.", cxxopts::value<string>()->default_value(""))
 	    ("id", "Identity (basename) of keypair", cxxopts::value<string>()->default_value(""))
-	    ("b64,base64", "Treat ciphertext as base64 encoded (default: off)", cxxopts::value<string>())
+	    ("base64", "Treat ciphertext as base64 encoded (default: off)", cxxopts::value<bool>())
 	    ("keypair-path", "Path to keypair (default: cwd)", cxxopts::value<string>())
 	    ("h,help", "Print usage")
 	;

--- a/src/exe/mick/mick.cpp
+++ b/src/exe/mick/mick.cpp
@@ -1,6 +1,8 @@
 /* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
 
 #include "mcleece/actions.h"
+#include "serialize/b64_instream.h"
+#include "serialize/b64_outstream.h"
 
 #include "cxxopts/cxxopts.hpp"
 extern "C" {
@@ -53,6 +55,7 @@ int main(int argc, char** argv)
 	    ("i,input", "Input file. Required for [encrypt|decrypt]", cxxopts::value<string>()->default_value(""))
 	    ("o,output", "Output file. No value -> stdout.", cxxopts::value<string>()->default_value(""))
 	    ("id", "Identity (basename) of keypair", cxxopts::value<string>()->default_value(""))
+	    ("b64,base64", "Treat ciphertext as base64 encoded (default: off)", cxxopts::value<string>())
 	    ("keypair-path", "Path to keypair (default: cwd)", cxxopts::value<string>())
 	    ("h,help", "Print usage")
 	;
@@ -63,6 +66,8 @@ int main(int argc, char** argv)
 	auto result = options.parse(argc, argv);
 	if (result.count("help") or !result.count("command"))
 		return help(options);
+
+	bool b64 = result.count("base64");
 
 	string key_path = get_working_path();
 	if (result.count("keypair-path"))
@@ -95,11 +100,21 @@ int main(int argc, char** argv)
 		string output = result["output"].as<string>();
 
 		if (output.empty())
-			return mcleece::actions::encrypt(key, istream, std::cout);
+		{
+			if (!b64)
+				return mcleece::actions::encrypt(key, istream, std::cout);
+
+			b64_outstream bo(std::cout);
+			return mcleece::actions::encrypt(key, istream, bo);
+		}
 		else
 		{
 			std::ofstream f(output, std::ios::binary);
-			return mcleece::actions::encrypt(key, istream, f);
+			if (!b64)
+				return mcleece::actions::encrypt(key, istream, f);
+
+			b64_outstream bo(f);
+			return mcleece::actions::encrypt(key, istream, bo);
 		}
 	}
 
@@ -114,14 +129,21 @@ int main(int argc, char** argv)
 		string key = fmt::format("{}/{}.sk", key_path, id);
 		string pw = get_pw();
 		std::ifstream istream(input, std::ios::binary);
+		b64_instream bi(istream);
 		string output = result["output"].as<string>();
 
 		if (output.empty())
-			return mcleece::actions::decrypt(key, pw, istream, std::cout);
+		{
+			if (!b64)
+				return mcleece::actions::decrypt(key, pw, istream, std::cout);
+			return mcleece::actions::decrypt(key, pw, bi, std::cout);
+		}
 		else
 		{
 			std::ofstream f(output, std::ios::binary);
-			return mcleece::actions::decrypt(key, pw, istream, f);
+			if (!b64)
+				return mcleece::actions::decrypt(key, pw, istream, f);
+			return mcleece::actions::decrypt(key, pw, bi, f);
 		}
 	}
 

--- a/src/lib/serialize/CMakeLists.txt
+++ b/src/lib/serialize/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(SOURCES
+	b64_outstream.h
 	format.h
 )
 
 add_library(serialize INTERFACE)
+
+add_subdirectory(test)
 

--- a/src/lib/serialize/CMakeLists.txt
+++ b/src/lib/serialize/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 set(SOURCES
+	b64_instream.h
 	b64_outstream.h
 	format.h
 )

--- a/src/lib/serialize/b64_instream.h
+++ b/src/lib/serialize/b64_instream.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "base64/base.hpp"
+#include <array>
+#include <string>
+#include <vector>
+
+template <typename INSTREAM>
+class b64_instream
+{
+public:
+	b64_instream(INSTREAM& stream)
+		: _stream(stream)
+	{}
+
+	operator bool() const
+	{
+		return good();
+	}
+
+	bool good() const
+	{
+		return _stream.good();
+	}
+
+	std::streamsize gcount() const
+	{
+		return _readBytes;
+	}
+
+	b64_instream& read(char* decodeBuff, unsigned length)
+	{
+		_readBytes = 0;
+		while (good() && length > 0)
+		{
+			unsigned maxRead = std::min<unsigned>(length * 4 / 3, _buffer.size());
+			_stream.read(_buffer.data(), maxRead);
+			unsigned readLen = _stream.gcount();
+
+			std::string decoded = base64::decode(std::string(_buffer.data(), readLen));
+			std::copy(decoded.data(), decoded.data() + decoded.size(), decodeBuff);
+
+			_readBytes += decoded.size();
+			decodeBuff += decoded.size();
+			length -= decoded.size();
+		}
+		return *this;
+	}
+
+protected:
+	INSTREAM& _stream;
+	unsigned _readBytes = 0;
+	std::array<char, 8192> _buffer;
+};

--- a/src/lib/serialize/b64_outstream.h
+++ b/src/lib/serialize/b64_outstream.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "base64/base.hpp"
+#include <array>
+#include <string>
+#include <vector>
+
+template <typename OUTSTREAM>
+class b64_outstream
+{
+public:
+	b64_outstream(OUTSTREAM& stream)
+		: _stream(stream)
+	{}
+
+	~b64_outstream()
+	{
+		try {
+			flush();
+		} catch (const std::exception& e) {}  // it's not the end of the world -- we just failed to write
+	}
+
+	b64_outstream& write(const char* data, unsigned length)
+	{
+		if (length == 0)
+		{
+			flush();
+			return *this;
+		}
+
+		if (_eidx)
+		{
+			unsigned remainder = std::min<unsigned>(_extra.size() - _eidx, length);
+			std::copy(data, data+remainder, &_extra[_eidx]);
+			data += remainder;
+			length -= remainder;
+
+			if (remainder + _eidx == _extra.size())
+				flush();
+		}
+
+		_eidx = length % 3;
+		if (_eidx != 0)
+		{
+			length -= _eidx;
+			std::copy(data+length, data+length+_eidx, _extra.data());
+		}
+
+		write_direct(data, length);
+		return *this;
+	}
+
+	b64_outstream& operator<<(const std::string& buffer)
+	{
+		return write(buffer.data(), buffer.size());
+	}
+
+	bool flush()
+	{
+		if (!_eidx)
+			return false;
+
+		int res = write_direct(_extra.data(), _eidx);
+		_eidx = 0;
+		return res;
+	}
+
+protected:
+	int write_direct(const char* data, unsigned length)
+	{
+		std::string encoded = base64::encode(std::string(data, length));
+		_stream.write(encoded.data(), encoded.size());
+		return encoded.size();
+	}
+
+protected:
+	OUTSTREAM& _stream;
+	std::array<char, 3> _extra;
+	unsigned _eidx = 0;
+};

--- a/src/lib/serialize/test/CMakeLists.txt
+++ b/src/lib/serialize/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(serialize_test)
+
+set (SOURCES
+	test.cpp
+	b64_instreamTest.cpp
+	b64_outstreamTest.cpp
+)
+
+include_directories(
+	${libmcleece_proj_SOURCE_DIR}/test
+	${libmcleece_proj_SOURCE_DIR}/test/lib
+	${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_executable (
+	serialize_test
+	${SOURCES}
+)
+
+add_test(serialize_test serialize_test)
+
+target_link_libraries(serialize_test
+
+	${CPPFILESYSTEM}
+)
+

--- a/src/lib/serialize/test/b64_instreamTest.cpp
+++ b/src/lib/serialize/test/b64_instreamTest.cpp
@@ -1,0 +1,67 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+
+#include "serialize/b64_instream.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using std::string;
+
+
+TEST_CASE( "b64_instreamTest/testDecode.Simple", "[unit]" )
+{
+	std::stringstream ss;
+	ss << "aGVsbG8gZnJpZW5kcw==";
+	b64_instream bs(ss);
+
+	assertTrue(bs);
+
+	std::string buff;
+	buff.resize(20);
+
+	bs.read(buff.data(), buff.size());
+	assertEquals(13, bs.gcount());
+	buff.resize(bs.gcount());
+
+	assertFalse(bs);
+
+	assertEquals( "hello friends", buff );
+}
+
+TEST_CASE( "b64_instreamTest/testDecode.Piecemeal", "[unit]" )
+{
+	std::stringstream ss;
+	ss << "aGVsbG8gZnJpZW5kcw==";
+	b64_instream bs(ss);
+
+	assertTrue(bs);
+
+	std::string buff;
+	buff.resize(6);
+
+	bs.read(buff.data(), buff.size());
+	assertEquals(6, bs.gcount());
+	assertEquals( "hello ", buff );
+
+	assertTrue( bs );
+
+	bs.read(buff.data(), buff.size());
+	assertEquals(6, bs.gcount());
+	buff.resize(bs.gcount());
+	assertEquals( "friend", buff );
+
+	assertTrue( bs );
+
+	bs.read(buff.data(), buff.size());
+	assertEquals(1, bs.gcount());
+	buff.resize(bs.gcount());
+	assertEquals( "s", buff );
+
+	assertFalse( bs );
+
+	bs.read(buff.data(), buff.size());
+	assertEquals(0, bs.gcount());
+	buff.resize(bs.gcount());
+	assertEquals( "", buff );
+}

--- a/src/lib/serialize/test/b64_outstreamTest.cpp
+++ b/src/lib/serialize/test/b64_outstreamTest.cpp
@@ -1,0 +1,37 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+
+#include "serialize/b64_outstream.h"
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using std::string;
+
+
+TEST_CASE( "b64_outstreamTest/testEncode.Simple", "[unit]" )
+{
+	std::stringstream ss;
+	b64_outstream bs(ss);
+
+	bs << "hello friends";
+
+	assertEquals( "aGVsbG8gZnJpZW5k", ss.str() );
+
+	assertTrue( bs.flush() );
+	assertEquals( "aGVsbG8gZnJpZW5kcw==", ss.str() );
+
+	assertFalse( bs.flush() );
+	assertEquals( "aGVsbG8gZnJpZW5kcw==", ss.str() );
+}
+
+TEST_CASE( "b64_streamTest/testEncode.FlushOnDestructor", "[unit]" )
+{
+	std::stringstream ss;
+	{
+		b64_outstream bs(ss);
+		bs << "hello friends";
+	}
+
+	assertEquals( "aGVsbG8gZnJpZW5kcw==", ss.str() );
+}

--- a/src/lib/serialize/test/test.cpp
+++ b/src/lib/serialize/test/test.cpp
@@ -1,0 +1,4 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+


### PR DESCRIPTION
I'll probably make this the default.