### PR TITLE
Add no-copy dual-layer crypto_box functions

### DIFF
--- a/src/lib/mcleece/CMakeLists.txt
+++ b/src/lib/mcleece/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
 	mcleece.h
 
 	actions.h
+	easy.h
 	keygen.h
 	message.h
 	nonce.h

--- a/src/lib/mcleece/actions.h
+++ b/src/lib/mcleece/actions.h
@@ -28,7 +28,7 @@ namespace actions {
 		return mcleece::generate_keypair(fmt::format("{}.pk", keypath), fmt::format("{}.sk", keypath), pw);
 	}
 
-	inline int encrypt(mcleece::byte_view& output_c, mcleece::byte_view message, const unsigned char* pubk)
+	inline int encrypt(mcleece::byte_view output_c, mcleece::byte_view message, const unsigned char* pubk)
 	{
 		// generate session key. nonce initiallized to a random value, and incremented by 1 for every message
 		// we only use multiple messages when the input is larger than the arbitrary MAX_LENGTH below
@@ -49,7 +49,7 @@ namespace actions {
 		return 0;
 	}
 
-	inline int decrypt(mcleece::byte_view& output_m, mcleece::byte_view ciphertext, const unsigned char* secret)
+	inline int decrypt(mcleece::byte_view output_m, mcleece::byte_view ciphertext, const unsigned char* secret)
 	{
 		// extract the session from the front of the input
 		if (ciphertext.size() < mcleece::session_header_size())

--- a/src/lib/mcleece/easy.h
+++ b/src/lib/mcleece/easy.h
@@ -14,7 +14,7 @@ namespace easy {
 
 	static const unsigned PUBLIC_KEY_SIZE = mcleece::public_key::size() + crypto_box_PUBLICKEYBYTES;
 	static const unsigned SECRET_KEY_SIZE = mcleece::private_key::size() + crypto_box_SECRETKEYBYTES;
-	static const unsigned MESSAGE_HEADER_SIZE = mcleece::actions::MESSAGE_HEADER_SIZE + crypto_box_SEALBYTES;
+	static const unsigned FULL_MESSAGE_HEADER_SIZE = mcleece::actions::MESSAGE_HEADER_SIZE + crypto_box_SEALBYTES;
 
 	inline int crypto_box_keypair(unsigned char* pubk, unsigned char* secret)
 	{
@@ -31,7 +31,7 @@ namespace easy {
 
 	inline int crypto_box_seal(mcleece::byte_view& output_c, mcleece::byte_view message, const unsigned char* pubk)
 	{
-		if (output_c.size() < message.size() + MESSAGE_HEADER_SIZE)
+		if (output_c.size() < message.size() + FULL_MESSAGE_HEADER_SIZE)
 			return 65;
 
 		// inner layer: crypto_box. outer layer: libmcleece encrypt
@@ -52,7 +52,7 @@ namespace easy {
 
 	inline int crypto_box_seal_open(mcleece::byte_view& output_m, mcleece::byte_view ciphertext, const unsigned char* pubk, const unsigned char* secret)
 	{
-		if (ciphertext.size() < MESSAGE_HEADER_SIZE)
+		if (ciphertext.size() < FULL_MESSAGE_HEADER_SIZE)
 			return 65;
 
 		std::string scratch;
@@ -76,13 +76,12 @@ namespace easy {
 		// message contains the data going on, and will be overwritten with the final ciphertext.
 		// scratch will hold the intermediate representation -- a normal libsodium crypto_box_seal result
 		// inner layer: crypto_box. outer layer: libmcleece encrypt
-		if (message.size() < MESSAGE_HEADER_SIZE)
+		if (message.size() < FULL_MESSAGE_HEADER_SIZE)
 			return 65;
-
 		if (scratch.size() < message.size() - mcleece::actions::MESSAGE_HEADER_SIZE)
-			return 65;
+			return 66;
 
-		mcleece::byte_view input(message.data(), message.size() - MESSAGE_HEADER_SIZE);
+		mcleece::byte_view input(message.data(), message.size() - FULL_MESSAGE_HEADER_SIZE);
 		int res = ::crypto_box_seal(const_cast<unsigned char*>(scratch.data()), input.data(), input.size(), pubk);
 		if (res != 0)
 			return 69;
@@ -99,7 +98,7 @@ namespace easy {
 
 	inline int cbox_seal_open_nomalloc(mcleece::byte_view& message, mcleece::byte_view& scratch, const unsigned char* pubk, const unsigned char* secret)
 	{
-		if (message.size() < MESSAGE_HEADER_SIZE)
+		if (message.size() < FULL_MESSAGE_HEADER_SIZE)
 			return 65;
 		if (scratch.size() < crypto_box_SEALBYTES)
 			return 66;
@@ -112,7 +111,7 @@ namespace easy {
 		if (res != 0)
 			return 69;
 
-		message = {message.data(), message.size() - MESSAGE_HEADER_SIZE};
+		message = {message.data(), message.size() - FULL_MESSAGE_HEADER_SIZE};
 		return 0;
 	}
 }}

--- a/src/lib/mcleece/mcleece.cpp
+++ b/src/lib/mcleece/mcleece.cpp
@@ -64,6 +64,20 @@ int mcleece_crypto_box_seal_open(unsigned char* decrypted_out, const unsigned ch
 	return mcleece::easy::crypto_box_seal_open(os, is, recipient_pubk, recipient_secret);
 }
 
+int mcleece_cbox_seal_nomalloc(unsigned char* buff, unsigned msg_and_header_length, unsigned char* scratch, unsigned char* recipient_pubk)
+{
+	mcleece::byte_view inout(buff, msg_and_header_length);
+	mcleece::byte_view scr(scratch, msg_and_header_length - mcleece_MESSAGE_HEADER_SIZE); // aka: msg_length + crypto_box_SEALBYTES
+	return mcleece::easy::cbox_seal_nomalloc(inout, scr, recipient_pubk);
+}
+
+int mcleece_cbox_seal_open_nomalloc(unsigned char* buff, unsigned ciphertext_length, unsigned char* scratch, unsigned char* recipient_pubk, unsigned char* recipient_secret)
+{
+	mcleece::byte_view inout(buff, ciphertext_length);
+	mcleece::byte_view scr(scratch, ciphertext_length - mcleece_MESSAGE_HEADER_SIZE); // aka: msg_length + crypto_box_SEALBYTES
+	return mcleece::easy::cbox_seal_open_nomalloc(inout, scr, recipient_pubk, recipient_secret);
+}
+
 int mcleece_encrypt_file(char* keypath, unsigned keypath_len, char* srcpath, unsigned srcpath_len, char* dstpath, unsigned dstpath_len, int flags)
 {
 	std::ifstream istream(string(srcpath, srcpath_len), std::ios::binary);

--- a/src/lib/mcleece/mcleece.cpp
+++ b/src/lib/mcleece/mcleece.cpp
@@ -19,7 +19,7 @@ const unsigned mcleece_MESSAGE_HEADER_SIZE = mcleece::actions::MESSAGE_HEADER_SI
 
 const unsigned mcleece_crypto_box_PUBLIC_KEY_SIZE = mcleece::easy::PUBLIC_KEY_SIZE;
 const unsigned mcleece_crypto_box_SECRET_KEY_SIZE = mcleece::easy::SECRET_KEY_SIZE;
-const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE = mcleece::easy::MESSAGE_HEADER_SIZE;
+const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE = mcleece::easy::FULL_MESSAGE_HEADER_SIZE;
 
 int mcleece_keypair(unsigned char* pubk, unsigned char* secret)
 {

--- a/src/lib/mcleece/mcleece.h
+++ b/src/lib/mcleece/mcleece.h
@@ -27,6 +27,9 @@ int mcleece_decrypt(unsigned char* decrypted_out, const unsigned char* ciphertex
 int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* msg, unsigned msg_length, unsigned char* recipient_pubk);
 int mcleece_crypto_box_seal_open(unsigned char* decrypted_out, const unsigned char* ciphertext, unsigned ciphertext_length, unsigned char* recipient_pubk, unsigned char* recipient_secret);
 
+int mcleece_cbox_seal_nomalloc(unsigned char* buff, unsigned msg_and_header_length, unsigned char* scratch, unsigned char* recipient_pubk);
+int mcleece_cbox_seal_open_nomalloc(unsigned char* buff, unsigned ciphertext_length, unsigned char* scratch, unsigned char* recipient_pubk, unsigned char* recipient_secret);
+
 int mcleece_encrypt_file(char* keypath, unsigned keypath_len, char* srcpath, unsigned srcpath_len, char* dstpath, unsigned dstpath_len, int flags);
 int mcleece_encrypt_stdout(char* keypath, unsigned keypath_len, char* srcpath, unsigned srcpath_len, int flags);
 

--- a/src/lib/mcleece/test/easyTest.cpp
+++ b/src/lib/mcleece/test/easyTest.cpp
@@ -11,31 +11,30 @@ using std::string;
 TEST_CASE( "easyTest/testRoundtrip", "[unit]" )
 {
 	std::vector<unsigned char> pubk;
-	pubk.resize(mcleece_PUBLIC_KEY_SIZE);
+	pubk.resize(mcleece_crypto_box_PUBLIC_KEY_SIZE);
 
 	std::vector<unsigned char> secret;
-	secret.resize(mcleece_SECRET_KEY_SIZE);
+	secret.resize(mcleece_crypto_box_SECRET_KEY_SIZE);
 
 	{
-		int res = mcleece_keypair(pubk.data(), secret.data());
+		int res = mcleece_crypto_box_keypair(pubk.data(), secret.data());
 		assertEquals( 0, res );
 	}
 
 	string srcMessage = "hello friends";
 	std::vector<unsigned char> cipherText;
-	cipherText.resize(srcMessage.size() + mcleece_MESSAGE_HEADER_SIZE);
+	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
 	{
-		int res = mcleece_encrypt(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
+		int res = mcleece_crypto_box_seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
 		assertEquals( 0, res );
 	}
 
 	string dstMessage;
 	dstMessage.resize(srcMessage.size());
 	{
-		int res = mcleece_decrypt(reinterpret_cast<unsigned char*>(dstMessage.data()), cipherText.data(), cipherText.size(), secret.data());
+		int res = mcleece_crypto_box_seal_open(reinterpret_cast<unsigned char*>(dstMessage.data()), cipherText.data(), cipherText.size(), pubk.data(), secret.data());
 		assertEquals(0, res);
 	}
 
 	assertEquals( "hello friends", dstMessage );
 }
-

--- a/src/lib/mcleece/test/easyTest.cpp
+++ b/src/lib/mcleece/test/easyTest.cpp
@@ -38,3 +38,42 @@ TEST_CASE( "easyTest/testRoundtrip", "[unit]" )
 
 	assertEquals( "hello friends", dstMessage );
 }
+
+
+TEST_CASE( "easyTest/testNomallocRoundtrip", "[unit]" )
+{
+	// alternative API to reuse the input buffer for output...
+	std::vector<unsigned char> pubk;
+	pubk.resize(mcleece_crypto_box_PUBLIC_KEY_SIZE);
+
+	std::vector<unsigned char> secret;
+	secret.resize(mcleece_crypto_box_SECRET_KEY_SIZE);
+
+	{
+		int res = mcleece_crypto_box_keypair(pubk.data(), secret.data());
+		assertEquals( 0, res );
+	}
+
+	string message = "hello friends";
+	message.resize(message.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
+
+	{
+		std::vector<unsigned char> scratch;
+		scratch.resize(message.size() - mcleece_MESSAGE_HEADER_SIZE);
+		int res = mcleece_cbox_seal_nomalloc(reinterpret_cast<unsigned char*>(message.data()), message.size(), scratch.data(), pubk.data());
+		assertEquals( 0, res );
+	}
+
+	// message is now our encrypted buffer
+	assertTrue( message.substr(5) != "hello" );
+
+	{
+		std::vector<unsigned char> scratch;
+		scratch.resize(message.size() - mcleece_MESSAGE_HEADER_SIZE);
+		int res = mcleece_cbox_seal_open_nomalloc(reinterpret_cast<unsigned char*>(message.data()), message.size(), scratch.data(), pubk.data(), secret.data());
+		assertEquals(0, res);
+	}
+
+	assertEquals( "hello friends", message );
+}
+

--- a/src/lib/mcleece/test/easyTest.cpp
+++ b/src/lib/mcleece/test/easyTest.cpp
@@ -56,16 +56,19 @@ TEST_CASE( "easyTest/testNomallocRoundtrip", "[unit]" )
 
 	string message = "hello friends";
 	message.resize(message.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
+	assertTrue( message.substr(0, 5) == "hello" );
 
 	{
 		std::vector<unsigned char> scratch;
 		scratch.resize(message.size() - mcleece_MESSAGE_HEADER_SIZE);
 		int res = mcleece_cbox_seal_nomalloc(reinterpret_cast<unsigned char*>(message.data()), message.size(), scratch.data(), pubk.data());
 		assertEquals( 0, res );
+
+		// assert we can decrypt the libsodium part from `scratch`??
 	}
 
 	// message is now our encrypted buffer
-	assertTrue( message.substr(5) != "hello" );
+	assertTrue( message.substr(0, 5) != "hello" );
 
 	{
 		std::vector<unsigned char> scratch;
@@ -74,6 +77,7 @@ TEST_CASE( "easyTest/testNomallocRoundtrip", "[unit]" )
 		assertEquals(0, res);
 	}
 
+	message.resize(13);
 	assertEquals( "hello friends", message );
 }
 


### PR DESCRIPTION
Called `cbox_seal_nomalloc` no here, though I ended up changing it.

See #9.