### PR TITLE
Test macOS build too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,6 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --target install -j 2
 
-    - name: Setup tests
-      working-directory: ${{runner.workspace}}/libmcleece
-      shell: bash
-      run: |
-         (cd dist/bin/ && (echo "password" | ./mcleececli keypair -s --key-path=/tmp/test))
-         (cd dist/bin/ && (echo "password" | ./mcleececli keypair --key-path=/tmp/cbox))
-
     - name: Test
       working-directory: ${{runner.workspace}}/build
       run: ctest --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,36 +2,32 @@ name: ci
 
 on: [push, pull_request]
 
+env:
+  BUILD_TYPE: Release
+
 jobs:
   build:
-    name: ${{ matrix.config.name }}
-    runs-on: ${{ matrix.config.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        config:
-        - name: "linux gcc7"
-          os: ubuntu-18.04
-          cc: "gcc-7"
-          cxx: "g++-7"
-        - name: "linux clang"
-          os: ubuntu-18.04
-          cc: "clang"
-          cxx: "clang++"
+        os: [ubuntu-18.04, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Install dependencies
-      run: sudo apt-get install libssl-dev libsodium-dev
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake
+      shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: CXX=${{ matrix.config.cxx }} CC=${{ matrix.config.cc }} cmake $GITHUB_WORKSPACE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_LIBSODIUM=1
 
     - name: Build
+      shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cmake --build . --target install -j 2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: make -j2 && make install
+      run: cmake --build . --target install -j 2
 
     - name: Setup tests
       working-directory: ${{runner.workspace}}/libmcleece
@@ -44,7 +44,7 @@ jobs:
 
     - name: Test
       working-directory: ${{runner.workspace}}/build
-      run: make test CTEST_OUTPUT_ON_FAILURE=TRUE
+      run: ctest --output-on-failure
 
   cppcheck:
     runs-on: ubuntu-18.04

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(DEFINED BUILD_LIBSODIUM)
 	include_directories("${libmcleece_proj_SOURCE_DIR}/libsodium/libsodium/src/libsodium/include/")
 endif()
 
-if(NOT DEFINED CPPFILESYSTEM)
+if(NOT DEFINED CPPFILESYSTEM AND NOT APPLE)
     set(CPPFILESYSTEM "stdc++fs")
 endif()
 

--- a/src/exe/mcleececli/CMakeLists.txt
+++ b/src/exe/mcleececli/CMakeLists.txt
@@ -14,11 +14,13 @@ target_link_libraries(mcleececli
 	mcleece_static
 )
 
+if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 add_custom_command(
 	TARGET mcleececli POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mcleececli> mcleececli.dbg
 	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:mcleececli>
 )
+endif()
 
 install(
 	TARGETS mcleececli

--- a/src/lib/mcleece/CMakeLists.txt
+++ b/src/lib/mcleece/CMakeLists.txt
@@ -41,11 +41,13 @@ target_link_libraries(mcleece
 	sodium
 )
 
+if("${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
 add_custom_command(
 	TARGET mcleece POST_BUILD
 	COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mcleece> mcleece.dbg
 	COMMAND ${CMAKE_STRIP} -g $<TARGET_FILE:mcleece>
 )
+endif()
 
 set_target_properties(mcleece PROPERTIES PUBLIC_HEADER mcleece.h)
 

--- a/test/TestHelpers.h
+++ b/test/TestHelpers.h
@@ -8,20 +8,17 @@
 
 namespace TestHelpers
 {
-	inline bool generate_keypair(std::experimental::filesystem::path target_prefix, int mode=mcleece::SIMPLE)
+	inline void generate_keypair(std::experimental::filesystem::path target_prefix, int mode=mcleece::SIMPLE)
 	{
 		std::string basename = std::experimental::filesystem::path(target_prefix).filename();
-		std::string pk = std::experimental::filesystem::temp_directory_path() / fmt::format("{}.pk", basename);
-		std::string sk = std::experimental::filesystem::temp_directory_path() / fmt::format("{}.sk", basename);
-		if (File(pk).good() and File(sk).good())
-		{
-			std::experimental::filesystem::copy(pk, target_prefix.replace_extension(".pk"));
-			std::experimental::filesystem::copy(sk, target_prefix.replace_extension(".sk"));
-			return false;
-		}
-		else
-			mcleece::actions::keypair_to_file(target_prefix, "password", mode);
-		return true;
+		std::string path = std::experimental::filesystem::temp_directory_path() / basename;
+		std::string pk = fmt::format("{}.pk", path);
+		std::string sk = fmt::format("{}.sk", path);
+		if (!File(pk).good() or !File(sk).good())
+			mcleece::actions::keypair_to_file(path, "password", mode);
+
+		std::experimental::filesystem::copy(pk, target_prefix.replace_extension(".pk"));
+		std::experimental::filesystem::copy(sk, target_prefix.replace_extension(".sk"));
 	}
 }
 


### PR DESCRIPTION
These are mostly github actions changes. We lose the automated clang tests on linux, and now always build libsodium, but I'm ok with that for the sake of simplicity.

I might add additional linux platforms...