### PR TITLE
Hybrid key exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,25 +98,7 @@ The differences are:
 * `mcleece_crypto_box` operations have two layers of encryption. The first is libsodium's `crypto_box` (hence the name), the output of which is then wrapped in a `mcleece_simple` call. The `mcleece_simple` calls, therefore, are a single layer of encryption.
    * since PQC is new and exciting (even if Classic McEliece is fairly old-fashioned and safe), using the extra x25519 layer is probably a good idea, and as such, it is the default behavior for the cli.
 * `mcleece_crypto_box` keypairs are larger, since they contain two keypairs. Specifically, the x25519 key bytes are prepended in front of the Classic McEliece key bytes.
-* `mcleece_crypto_box_seal` and `mcleece_crypto_box_seal_open` *allocate extra memory* for the intermediate (libsodium) layer.
 
-## `mcleece_inplace_crypto_box_seal`
-As a workaround to the extra memory allocation in the standard `mcleece_crypto_box_seal` implementation, an alternative API is supported:
-```
-int mcleece_inplace_crypto_box_seal(unsigned char* buff, unsigned msg_and_header_length, unsigned char* scratch, unsigned char* recipient_pubk);
-int mcleece_inplace_crypto_box_seal_open(unsigned char* buff, unsigned ciphertext_length, unsigned char* scratch, unsigned char* recipient_pubk, unsigned char* recipient_secret);
-```
-
-These functions are meant to be used in conjunction with `mcleece_crypto_box_keypair`. Here's how they work:
-* `mcleece_inplace_crypto_box_seal(msg_buff, msg_size + mcleece_crypto_box_MESSAGE_HEADER_SIZE, scratch, pubk);`
-   * special attention must be given to the size of the buffer pointed to by `msg_buff`. Because the encrypted output will be written back to this buffer -- and because the encrypted output will be an extra `mcleece_crypto_box_MESSAGE_HEADER_SIZE` bytes long, the *input* message buffer will need to be oversized to make room. For example, if the input message is "hello", instead of `msg_and_header_length` being 5, it will be `5+mcleece_crypto_box_MESSAGE_HEADER_SIZE` -- the expected ciphertext length.
-   * `scratch` must be a distinct buffer from `msg_buff`, and must have room for `msg_size + mcleece_crypto_box_INNER_MESSAGE_HEADER_SIZE` bytes.
-   * after the call is complete -- if it returns 0 (no errors) -- msg_buff will contain `msg_and_header_length` bytes of encrypted data.
-* `mcleece_inplace_crypto_box_seal_open(msg_buff, ciphertext_length, scratch, pubk, secret);`
-   * the `*_seal_open` call behaves the same -- ciphertext_length should be the same as msg_and_header_length above, but since you presumably have all the bytes, no special adjustment is needed for msg_buff.
-   * where special attention is still needed is for `scratch` -- the size of the buffer here is `ciphertext_length - mcleece_simple_MESSAGE_HEADER_SIZE`, or `ciphertext_length - mcleece_crypto_box_MESSAGE_HEADER_SIZE + mcleece_crypto_box_INNER_MESSAGE_HEADER_SIZE` -- which should be identical. (obviously, make sure ciphertext_length is larger than the header size!)
-   * after this call is complete -- if it returns 0 (no errors) -- the first `ciphertext_length - mcleece_crypto_box_MESSAGE_HEADER_SIZE` bytes of msg_buff will contain the decrypted data.
-* Example code using these functions can be found in the tests, and also in the "file level" libmcleece APIs.
 
 ## C++ API
 It is not (yet?) collected in a single-header, but the core of libmcleece are a handful of header-only C++ libraries. These can also be used, though I'm not sure how stable the API is yet... 

--- a/src/lib/mcleece/actions.h
+++ b/src/lib/mcleece/actions.h
@@ -52,20 +52,12 @@ namespace actions {
 		if (!is)
 			return 66;
 
-		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::FULL_MESSAGE_HEADER_SIZE;
+		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MSG_HEADER_SIZE;
 
 		std::string data;
-		std::string scratch;
-		if constexpr(MODE == SIMPLE)
-		{
-			data.resize(max_length);
-			scratch.resize(max_length + header_length);
-		}
-		else
-		{
-			data.resize(max_length + header_length);
-			scratch.resize(max_length + mcleece::cbox::SODIUM_MESSAGE_HEADER_SIZE);
-		}
+		data.resize(max_length);
+		std::string output;
+		output.resize(max_length + header_length);
 
 		// encrypt each chunk
 		while (is)
@@ -75,24 +67,17 @@ namespace actions {
 			if (last_read == 0)
 				break;
 
+			mcleece::byte_view dataview(data.data(), last_read);
 			int res;
-			std::string_view ciphertext;
-
 			if constexpr(MODE == SIMPLE)
-			{
-				mcleece::byte_view dataview(data.data(), last_read);
-				res = mcleece::simple::encrypt(scratch, dataview, pubk);
-				ciphertext = {scratch.data(), last_read + header_length};
-			}
+				res = mcleece::simple::encrypt(output, dataview, pubk);
 			else
-			{
-				mcleece::byte_view dataview(data.data(), last_read + header_length);
-				mcleece::byte_view intermediate(scratch.data(), last_read + mcleece::cbox::SODIUM_MESSAGE_HEADER_SIZE);
-				res = mcleece::cbox::inplace_crypto_box_seal(dataview, intermediate, pubk);
-				ciphertext = {data.data(), last_read + header_length};
-			}
+				res = mcleece::cbox::crypto_box_seal(output, dataview, pubk);
+
 			if (res)
 				return res;
+
+			std::string_view ciphertext = {output.data(), last_read + header_length};
 			os << ciphertext;
 		}
 		return 0;
@@ -120,16 +105,12 @@ namespace actions {
 		if (!is)
 			return 66;
 
-		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::FULL_MESSAGE_HEADER_SIZE;
+		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MSG_HEADER_SIZE;
 
 		std::string data;
-		std::string scratch;
-
 		data.resize(max_length + header_length);
-		if constexpr(MODE == SIMPLE)
-			scratch.resize(max_length);
-		else
-			scratch.resize(max_length + mcleece::cbox::SODIUM_MESSAGE_HEADER_SIZE);
+		std::string output;
+		output.resize(max_length);
 
 		// extract the message bytes
 		while (is)
@@ -140,23 +121,17 @@ namespace actions {
 				break;
 
 			// decrypt the message
-			int res;
-			std::string_view plaintext;
 			mcleece::byte_view dataview(data.data(), last_read);
-
+			int res;
 			if constexpr(MODE == SIMPLE)
-			{
-				res = mcleece::simple::decrypt(scratch, dataview, secret);
-				plaintext = {scratch.data(), last_read - header_length};
-			}
+				res = mcleece::simple::decrypt(output, dataview, secret);
 			else
-			{
-				mcleece::byte_view intermediate(scratch.data(), last_read - mcleece::simple::MESSAGE_HEADER_SIZE);
-				res = mcleece::cbox::inplace_crypto_box_seal_open(dataview, intermediate, pubk, secret);
-				plaintext = {data.data(), last_read - header_length};
-			}
+				res = mcleece::cbox::crypto_box_seal_open(output, dataview, pubk, secret);
+
 			if (res)
 				return res;
+
+			std::string_view plaintext = {output.data(), last_read - header_length};
 			os << plaintext;
 		}
 		return 0;

--- a/src/lib/mcleece/actions.h
+++ b/src/lib/mcleece/actions.h
@@ -52,7 +52,7 @@ namespace actions {
 		if (!is)
 			return 66;
 
-		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MSG_HEADER_SIZE;
+		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MESSAGE_HEADER_SIZE;
 
 		std::string data;
 		data.resize(max_length);
@@ -105,7 +105,7 @@ namespace actions {
 		if (!is)
 			return 66;
 
-		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MSG_HEADER_SIZE;
+		const int header_length = (MODE == SIMPLE)? mcleece::simple::MESSAGE_HEADER_SIZE : mcleece::cbox::MESSAGE_HEADER_SIZE;
 
 		std::string data;
 		data.resize(max_length + header_length);

--- a/src/lib/mcleece/cbox.h
+++ b/src/lib/mcleece/cbox.h
@@ -16,9 +16,7 @@ namespace cbox {
 	static const unsigned PUBLIC_KEY_SIZE = mcleece::public_key_cbox::size();
 	static const unsigned SODIUM_PUBLIC_KEY_SIZE = mcleece::public_key_sodium::size();
 	static const unsigned SECRET_KEY_SIZE = mcleece::private_key_cbox::size();
-	static const unsigned SODIUM_MESSAGE_HEADER_SIZE = crypto_box_SEALBYTES;
-	static const unsigned FULL_MESSAGE_HEADER_SIZE = mcleece::simple::MESSAGE_HEADER_SIZE + SODIUM_MESSAGE_HEADER_SIZE;
-	static const unsigned MSG_HEADER_SIZE = mcleece::session_key::size() + crypto_box_SEALBYTES;
+	static const unsigned MESSAGE_HEADER_SIZE = mcleece::session_key::size() + crypto_box_SEALBYTES;
 
 	inline int crypto_box_keypair(public_key_cbox& pubk, private_key_cbox& secret)
 	{
@@ -72,7 +70,7 @@ namespace cbox {
 
 	inline int crypto_box_seal(mcleece::byte_view output_c, const mcleece::byte_view message, const mcleece::public_key_cbox& pubk)
 	{
-		if (output_c.size() < message.size() + MSG_HEADER_SIZE)
+		if (output_c.size() < message.size() + MESSAGE_HEADER_SIZE)
 			return 65;
 
 		mcleece::public_key_simple pks(pubk.data() + crypto_box_PUBLICKEYBYTES);
@@ -91,7 +89,7 @@ namespace cbox {
 		if (!pubk.good())
 			return 64;
 
-		if (ciphertext.size() < MSG_HEADER_SIZE)
+		if (ciphertext.size() < MESSAGE_HEADER_SIZE)
 			return 65;
 
 		mcleece::private_key_simple sk(secret.data() + crypto_box_SECRETKEYBYTES);
@@ -103,50 +101,5 @@ namespace cbox {
 		mcleece::sodium_crypto_box box(pubk.data(), secret.data());
 		box.mix(mix);
 		return box.seal_open(const_cast<unsigned char*>(output_m.data()), ciphertext.data(), ciphertext.size());
-	}
-
-	// `message` should be plaintext sized to len(message) + MESSAGE_HEADER_SIZE
-	inline int inplace_crypto_box_seal(mcleece::byte_view message, mcleece::byte_view scratch, const mcleece::public_key_cbox& pubk)
-	{
-		// message contains the data going on, and will be overwritten with the final ciphertext.
-		// scratch will hold the intermediate representation -- a normal libsodium crypto_box_seal result
-		// inner layer: crypto_box. outer layer: libmcleece encrypt
-		if (message.size() < FULL_MESSAGE_HEADER_SIZE)
-			return 65;
-		if (scratch.size() < message.size() - mcleece::simple::MESSAGE_HEADER_SIZE)
-			return 66;
-
-		mcleece::byte_view input(message.data(), message.size() - FULL_MESSAGE_HEADER_SIZE);
-		int res = ::crypto_box_seal(const_cast<unsigned char*>(scratch.data()), input.data(), input.size(), pubk.data());
-		if (res != 0)
-			return 69;
-
-		mcleece::byte_view ciphertext = message;
-		mcleece::public_key_simple pk(pubk.data() + crypto_box_PUBLICKEYBYTES);
-		res = mcleece::simple::encrypt(ciphertext, scratch, pk);
-		if (res != 0)
-			return 6 + res;
-
-		return 0;
-	}
-
-	inline int inplace_crypto_box_seal_open(mcleece::byte_view message, mcleece::byte_view scratch, const mcleece::public_key_sodium& pubk, const mcleece::private_key_cbox& secret)
-	{
-		if (message.size() < FULL_MESSAGE_HEADER_SIZE)
-			return 65;
-		if (scratch.size() < crypto_box_SEALBYTES)
-			return 66;
-
-		mcleece::private_key_simple sk(secret.data() + crypto_box_SECRETKEYBYTES);
-		int res = mcleece::simple::decrypt(scratch, message, sk);
-		if (res != 0)
-			return 6 + res;
-
-		res = ::crypto_box_seal_open(const_cast<unsigned char*>(message.data()), scratch.data(), scratch.size(), pubk.data(), secret.data());
-		if (res != 0)
-			return 69;
-
-		message = {message.data(), message.size() - FULL_MESSAGE_HEADER_SIZE};
-		return 0;
 	}
 }}

--- a/src/lib/mcleece/cbox.h
+++ b/src/lib/mcleece/cbox.h
@@ -88,6 +88,9 @@ namespace cbox {
 
 	inline int crypto_box_seal_open(mcleece::byte_view output_m, const mcleece::byte_view ciphertext, const mcleece::public_key_sodium& pubk, const mcleece::private_key_cbox& secret)
 	{
+		if (!pubk.good())
+			return 64;
+
 		if (ciphertext.size() < MSG_HEADER_SIZE)
 			return 65;
 

--- a/src/lib/mcleece/mcleece.cpp
+++ b/src/lib/mcleece/mcleece.cpp
@@ -22,6 +22,7 @@ const unsigned mcleece_crypto_box_SODIUM_PUBLIC_KEY_SIZE = mcleece::cbox::SODIUM
 const unsigned mcleece_crypto_box_SECRET_KEY_SIZE = mcleece::cbox::SECRET_KEY_SIZE;
 const unsigned mcleece_crypto_box_SODIUM_MESSAGE_HEADER_SIZE = mcleece::cbox::SODIUM_MESSAGE_HEADER_SIZE;
 const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE = mcleece::cbox::FULL_MESSAGE_HEADER_SIZE;
+const unsigned mcleece_crypto_box_MSG_HEADER_SIZE = mcleece::cbox::MSG_HEADER_SIZE;
 
 const int mcleece_MODE_SIMPLE = mcleece::SIMPLE;
 const int mcleece_MODE_CRYPTO_BOX = mcleece::CBOX;
@@ -59,7 +60,7 @@ int mcleece_simple_decrypt(unsigned char* decrypted_out, const unsigned char* ci
 int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* msg, unsigned msg_length, unsigned char* recipient_pubk)
 {
 	mcleece::byte_view is(msg, msg_length);
-	mcleece::byte_view os(ciphertext_out, msg_length + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
+	mcleece::byte_view os(ciphertext_out, msg_length + mcleece_crypto_box_MSG_HEADER_SIZE);
 	mcleece::public_key_cbox rpk(recipient_pubk);
 	return mcleece::cbox::crypto_box_seal(os, is, rpk);
 }
@@ -67,7 +68,7 @@ int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* 
 int mcleece_crypto_box_seal_open(unsigned char* decrypted_out, const unsigned char* ciphertext, unsigned ciphertext_length, unsigned char* recipient_pubk, unsigned char* recipient_secret)
 {
 	mcleece::byte_view is(ciphertext, ciphertext_length);
-	mcleece::byte_view os(decrypted_out, ciphertext_length - mcleece_crypto_box_MESSAGE_HEADER_SIZE);
+	mcleece::byte_view os(decrypted_out, ciphertext_length - mcleece_crypto_box_MSG_HEADER_SIZE);
 	mcleece::public_key_sodium rpk(recipient_pubk);
 	mcleece::private_key_cbox rsk(recipient_secret);
 	return mcleece::cbox::crypto_box_seal_open(os, is, rpk, rsk);

--- a/src/lib/mcleece/mcleece.cpp
+++ b/src/lib/mcleece/mcleece.cpp
@@ -5,6 +5,8 @@
 #include "cbox.h"
 #include "constants.h"
 #include "message.h"
+#include "private_key.h"
+#include "public_key.h"
 #include "simple.h"
 #include "util/byte_view.h"
 #include <fstream>
@@ -20,9 +22,7 @@ const unsigned mcleece_simple_MESSAGE_HEADER_SIZE = mcleece::simple::MESSAGE_HEA
 const unsigned mcleece_crypto_box_PUBLIC_KEY_SIZE = mcleece::cbox::PUBLIC_KEY_SIZE;
 const unsigned mcleece_crypto_box_SODIUM_PUBLIC_KEY_SIZE = mcleece::cbox::SODIUM_PUBLIC_KEY_SIZE;
 const unsigned mcleece_crypto_box_SECRET_KEY_SIZE = mcleece::cbox::SECRET_KEY_SIZE;
-const unsigned mcleece_crypto_box_SODIUM_MESSAGE_HEADER_SIZE = mcleece::cbox::SODIUM_MESSAGE_HEADER_SIZE;
-const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE = mcleece::cbox::FULL_MESSAGE_HEADER_SIZE;
-const unsigned mcleece_crypto_box_MSG_HEADER_SIZE = mcleece::cbox::MSG_HEADER_SIZE;
+const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE = mcleece::cbox::MESSAGE_HEADER_SIZE;
 
 const int mcleece_MODE_SIMPLE = mcleece::SIMPLE;
 const int mcleece_MODE_CRYPTO_BOX = mcleece::CBOX;
@@ -60,7 +60,7 @@ int mcleece_simple_decrypt(unsigned char* decrypted_out, const unsigned char* ci
 int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* msg, unsigned msg_length, unsigned char* recipient_pubk)
 {
 	mcleece::byte_view is(msg, msg_length);
-	mcleece::byte_view os(ciphertext_out, msg_length + mcleece_crypto_box_MSG_HEADER_SIZE);
+	mcleece::byte_view os(ciphertext_out, msg_length + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
 	mcleece::public_key_cbox rpk(recipient_pubk);
 	return mcleece::cbox::crypto_box_seal(os, is, rpk);
 }
@@ -68,27 +68,10 @@ int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* 
 int mcleece_crypto_box_seal_open(unsigned char* decrypted_out, const unsigned char* ciphertext, unsigned ciphertext_length, unsigned char* recipient_pubk, unsigned char* recipient_secret)
 {
 	mcleece::byte_view is(ciphertext, ciphertext_length);
-	mcleece::byte_view os(decrypted_out, ciphertext_length - mcleece_crypto_box_MSG_HEADER_SIZE);
+	mcleece::byte_view os(decrypted_out, ciphertext_length - mcleece_crypto_box_MESSAGE_HEADER_SIZE);
 	mcleece::public_key_sodium rpk(recipient_pubk);
 	mcleece::private_key_cbox rsk(recipient_secret);
 	return mcleece::cbox::crypto_box_seal_open(os, is, rpk, rsk);
-}
-
-int mcleece_inplace_crypto_box_seal(unsigned char* buff, unsigned msg_and_header_length, unsigned char* scratch, unsigned char* recipient_pubk)
-{
-	mcleece::byte_view inout(buff, msg_and_header_length);
-	mcleece::byte_view scr(scratch, msg_and_header_length - mcleece_simple_MESSAGE_HEADER_SIZE); // aka: msg_length + crypto_box_SEALBYTES
-	mcleece::public_key_cbox rpk(recipient_pubk);
-	return mcleece::cbox::inplace_crypto_box_seal(inout, scr, rpk);
-}
-
-int mcleece_inplace_crypto_box_seal_open(unsigned char* buff, unsigned ciphertext_length, unsigned char* scratch, unsigned char* recipient_pubk, unsigned char* recipient_secret)
-{
-	mcleece::byte_view inout(buff, ciphertext_length);
-	mcleece::byte_view scr(scratch, ciphertext_length - mcleece_simple_MESSAGE_HEADER_SIZE); // aka: msg_length + crypto_box_SEALBYTES
-	mcleece::public_key_sodium rpk(recipient_pubk);
-	mcleece::private_key_cbox rsk(recipient_secret);
-	return mcleece::cbox::inplace_crypto_box_seal_open(inout, scr, rpk, rsk);
 }
 
 int mcleece_keypair_to_file(const char* keypath, unsigned keypath_len, const char* pw, unsigned pw_length, int mode)

--- a/src/lib/mcleece/mcleece.h
+++ b/src/lib/mcleece/mcleece.h
@@ -13,9 +13,7 @@ extern const unsigned mcleece_simple_MESSAGE_HEADER_SIZE;
 extern const unsigned mcleece_crypto_box_PUBLIC_KEY_SIZE;
 extern const unsigned mcleece_crypto_box_SODIUM_PUBLIC_KEY_SIZE;
 extern const unsigned mcleece_crypto_box_SECRET_KEY_SIZE;
-extern const unsigned mcleece_crypto_box_SODIUM_MESSAGE_HEADER_SIZE;
 extern const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE;
-extern const unsigned mcleece_crypto_box_MSG_HEADER_SIZE;
 
 extern const int mcleece_MODE_SIMPLE;
 extern const int mcleece_MODE_CRYPTO_BOX;
@@ -28,9 +26,6 @@ int mcleece_simple_decrypt(unsigned char* decrypted_out, const unsigned char* ci
 
 int mcleece_crypto_box_seal(unsigned char* ciphertext_out, const unsigned char* msg, unsigned msg_length, unsigned char* recipient_pubk);
 int mcleece_crypto_box_seal_open(unsigned char* decrypted_out, const unsigned char* ciphertext, unsigned ciphertext_length, unsigned char* recipient_pubk, unsigned char* recipient_secret);
-
-int mcleece_inplace_crypto_box_seal(unsigned char* buff, unsigned msg_and_header_length, unsigned char* scratch, unsigned char* recipient_pubk);
-int mcleece_inplace_crypto_box_seal_open(unsigned char* buff, unsigned ciphertext_length, unsigned char* scratch, unsigned char* recipient_pubk, unsigned char* recipient_secret);
 
 int mcleece_keypair_to_file(const char* keypath, unsigned keypath_len, const char* pw, unsigned pw_length, int mode);
 

--- a/src/lib/mcleece/mcleece.h
+++ b/src/lib/mcleece/mcleece.h
@@ -15,6 +15,7 @@ extern const unsigned mcleece_crypto_box_SODIUM_PUBLIC_KEY_SIZE;
 extern const unsigned mcleece_crypto_box_SECRET_KEY_SIZE;
 extern const unsigned mcleece_crypto_box_SODIUM_MESSAGE_HEADER_SIZE;
 extern const unsigned mcleece_crypto_box_MESSAGE_HEADER_SIZE;
+extern const unsigned mcleece_crypto_box_MSG_HEADER_SIZE;
 
 extern const int mcleece_MODE_SIMPLE;
 extern const int mcleece_MODE_CRYPTO_BOX;

--- a/src/lib/mcleece/message.h
+++ b/src/lib/mcleece/message.h
@@ -26,8 +26,8 @@ namespace message {
 			return 2;
 
 		int res = crypto_secretbox_easy(
-		    const_cast<unsigned char*>(ciphertext.data()), message.data(), message.size(),
-		    n.data(), session.key().data()
+			const_cast<unsigned char*>(ciphertext.data()), message.data(), message.size(),
+			n.data(), session.key().data()
 		);
 		if (res != 0)
 			return 3;
@@ -58,8 +58,8 @@ namespace message {
 			return 2;
 
 		unsigned res = crypto_secretbox_open_easy(
-		    const_cast<unsigned char*>(message.data()), ciphertext.data(), ciphertext.size(),
-		    n.data(), session.key().data()
+			const_cast<unsigned char*>(message.data()), ciphertext.data(), ciphertext.size(),
+			n.data(), session.key().data()
 		);
 		if (res != 0)
 			return 3;

--- a/src/lib/mcleece/sodium_crypto_box.h
+++ b/src/lib/mcleece/sodium_crypto_box.h
@@ -1,0 +1,34 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#pragma once
+
+#include "sodium/crypto_box.h"
+
+namespace mcleece {
+
+class sodium_crypto_box
+{
+public:
+	sodium_crypto_box(const unsigned char* pk, const unsigned char* sk=nullptr)
+	    : _pk(pk)
+	    , _sk(sk)
+	{}
+
+	int seal(unsigned char* c, const unsigned char* m, unsigned long long mlen)
+	{
+		return ::crypto_box_seal(c, m, mlen, _pk);
+	}
+
+	int seal_open(unsigned char* m, const unsigned char* c, unsigned long long clen)
+	{
+		if (_sk == nullptr)
+			return 1;
+
+		return ::crypto_box_seal_open(m, c, clen, _pk, _sk);
+	}
+
+protected:
+	const unsigned char* _pk;
+	const unsigned char* _sk;
+};
+
+}

--- a/src/lib/mcleece/sodium_crypto_box.h
+++ b/src/lib/mcleece/sodium_crypto_box.h
@@ -91,9 +91,9 @@ public:
 			return -10;
 
 		if (clen < crypto_box_SEALBYTES)
-			return -1;
+			return -9;
 		if (clen < crypto_box_PUBLICKEYBYTES)
-			return -2;
+			return -8;
 
 		mcleece::byte_view input(c, clen);
 
@@ -110,10 +110,10 @@ public:
 		// compute secret key
 		unsigned char k[crypto_box_BEFORENMBYTES];
 		if (crypto_box_beforenm(k, epk, _sk) != 0)
-			return -3;
+			return -7;
 
 		if (_mix and !_mix(input, k, nonce))
-			return -4;
+			return -6;
 
 		return ::crypto_secretbox_open_easy(m, input.data(), input.size(), nonce, k);
 	}

--- a/src/lib/mcleece/sodium_crypto_box.h
+++ b/src/lib/mcleece/sodium_crypto_box.h
@@ -1,4 +1,22 @@
-// MIT?
+// refactored/modified from libsodium crypto_box_seal
+/*
+ * ISC License
+ *
+ * Copyright (c) 2013-2022
+ * Frank Denis <j at pureftpd dot org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 #pragma once
 
 #include "util/byte_view.h"

--- a/src/lib/mcleece/sodium_crypto_box.h
+++ b/src/lib/mcleece/sodium_crypto_box.h
@@ -1,7 +1,10 @@
-/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+// MIT?
 #pragma once
 
 #include "sodium/crypto_box.h"
+#include "sodium/crypto_generichash.h"
+#include "sodium/crypto_secretbox.h"
+#include <algorithm>
 
 namespace mcleece {
 
@@ -13,15 +16,52 @@ public:
 	    , _sk(sk)
 	{}
 
+protected:
+	int compute_nonce(unsigned char *nonce, const unsigned char *pk1, const unsigned char *pk2)
+	{
+		crypto_generichash_state st;
+		crypto_generichash_init(&st, NULL, 0U, crypto_box_NONCEBYTES);
+		crypto_generichash_update(&st, pk1, crypto_box_PUBLICKEYBYTES);
+		crypto_generichash_update(&st, pk2, crypto_box_PUBLICKEYBYTES);
+		crypto_generichash_final(&st, nonce, crypto_box_NONCEBYTES);
+		return 0;
+	}
+
+public:
 	int seal(unsigned char* c, const unsigned char* m, unsigned long long mlen)
 	{
-		return ::crypto_box_seal(c, m, mlen, _pk);
+		unsigned char nonce[crypto_box_NONCEBYTES];
+		unsigned char epk[crypto_box_PUBLICKEYBYTES];
+		unsigned char esk[crypto_box_SECRETKEYBYTES];
+
+		// ephemeral keypair
+		if (crypto_box_keypair(epk, esk) != 0)
+			return -1;
+
+		// compute nonce
+		compute_nonce(nonce, epk, _pk);
+
+		// generate secret key
+		// TODO: assert crypto_box_BEFORENMBYTES >= crypto_secretbox_KEYBYTES
+		unsigned char k[crypto_box_BEFORENMBYTES];
+		::crypto_box_beforenm(k, _pk, esk);
+
+
+		int ret = ::crypto_secretbox_easy(c + crypto_box_PUBLICKEYBYTES, m, mlen, nonce, k);
+
+		std::copy(epk, epk+crypto_box_PUBLICKEYBYTES, c);
+		// TODO: zero out memory
+		/*sodium_memzero(esk, sizeof esk);
+		sodium_memzero(epk, sizeof epk);
+		sodium_memzero(nonce, sizeof nonce);*/
+
+		return ret;
 	}
 
 	int seal_open(unsigned char* m, const unsigned char* c, unsigned long long clen)
 	{
 		if (_sk == nullptr)
-			return 1;
+			return -2;
 
 		return ::crypto_box_seal_open(m, c, clen, _pk, _sk);
 	}

--- a/src/lib/mcleece/test/CMakeLists.txt
+++ b/src/lib/mcleece/test/CMakeLists.txt
@@ -11,6 +11,7 @@ set (SOURCES
 	messageTest.cpp
 	private_keyTest.cpp
 	simpleTest.cpp
+	sodiumCryptoBoxTest.cpp
 )
 
 include_directories(

--- a/src/lib/mcleece/test/cboxTest.cpp
+++ b/src/lib/mcleece/test/cboxTest.cpp
@@ -23,7 +23,7 @@ TEST_CASE( "cboxTest/testRoundtrip", "[unit]" )
 
 	string srcMessage = "hello friends";
 	std::vector<unsigned char> cipherText;
-	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MSG_HEADER_SIZE);
+	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
 	{
 		int res = mcleece_crypto_box_seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
 		assertEquals( 0, res );
@@ -36,48 +36,5 @@ TEST_CASE( "cboxTest/testRoundtrip", "[unit]" )
 		assertEquals(0, res);
 	}
 
-	assertEquals( "hello friends", dstMessage );
-}
-
-TEST_CASE( "cboxTest/testInplaceRoundtrip", "[unit]" )
-{
-	// alternative API to reuse the input buffer for output...
-	std::vector<unsigned char> pubk;
-	pubk.resize(mcleece_crypto_box_PUBLIC_KEY_SIZE);
-
-	std::vector<unsigned char> secret;
-	secret.resize(mcleece_crypto_box_SECRET_KEY_SIZE);
-
-	{
-		int res = mcleece_crypto_box_keypair(pubk.data(), secret.data());
-		assertEquals( 0, res );
-	}
-
-	string srcMessage = "hello friends";
-
-	string data = srcMessage;
-	data.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
-	assertTrue( data.substr(0, 5) == "hello" );
-
-	{
-		std::vector<unsigned char> scratch;
-		scratch.resize(data.size() - mcleece_simple_MESSAGE_HEADER_SIZE);
-		int res = mcleece_inplace_crypto_box_seal(reinterpret_cast<unsigned char*>(data.data()), data.size(), scratch.data(), pubk.data());
-		assertEquals( 0, res );
-
-		// assert we can decrypt the libsodium part from `scratch`??
-	}
-
-	// data is now our encrypted buffer
-	assertTrue( data.substr(0, 5) != "hello" );
-
-	{
-		std::vector<unsigned char> scratch;
-		scratch.resize(data.size() - mcleece_simple_MESSAGE_HEADER_SIZE);
-		int res = mcleece_inplace_crypto_box_seal_open(reinterpret_cast<unsigned char*>(data.data()), data.size(), scratch.data(), pubk.data(), secret.data());
-		assertEquals(0, res);
-	}
-
-	string dstMessage = data.substr(0, srcMessage.size());
 	assertEquals( "hello friends", dstMessage );
 }

--- a/src/lib/mcleece/test/cboxTest.cpp
+++ b/src/lib/mcleece/test/cboxTest.cpp
@@ -23,7 +23,7 @@ TEST_CASE( "cboxTest/testRoundtrip", "[unit]" )
 
 	string srcMessage = "hello friends";
 	std::vector<unsigned char> cipherText;
-	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
+	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MSG_HEADER_SIZE);
 	{
 		int res = mcleece_crypto_box_seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
 		assertEquals( 0, res );
@@ -79,75 +79,5 @@ TEST_CASE( "cboxTest/testInplaceRoundtrip", "[unit]" )
 	}
 
 	string dstMessage = data.substr(0, srcMessage.size());
-	assertEquals( "hello friends", dstMessage );
-}
-
-TEST_CASE( "cboxTest/testCrossValidation.1", "[unit]" )
-{
-	std::vector<unsigned char> pubk;
-	pubk.resize(mcleece_crypto_box_PUBLIC_KEY_SIZE);
-
-	std::vector<unsigned char> secret;
-	secret.resize(mcleece_crypto_box_SECRET_KEY_SIZE);
-
-	{
-		int res = mcleece_crypto_box_keypair(pubk.data(), secret.data());
-		assertEquals( 0, res );
-	}
-
-	string srcMessage = "hello friends";
-	string cipherText;
-	cipherText.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
-	{
-		int res = mcleece_crypto_box_seal(reinterpret_cast<unsigned char*>(cipherText.data()), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
-		assertEquals( 0, res );
-	}
-
-	std::vector<unsigned char> scratch;
-	scratch.resize(srcMessage.size() + mcleece_crypto_box_SODIUM_MESSAGE_HEADER_SIZE);
-	{
-		int res = mcleece_inplace_crypto_box_seal_open(reinterpret_cast<unsigned char*>(cipherText.data()), cipherText.size(), scratch.data(), pubk.data(), secret.data());
-		assertEquals(0, res);
-	}
-
-	string dstMessage = cipherText.substr(0, srcMessage.size());
-	assertEquals( "hello friends", dstMessage );
-}
-
-TEST_CASE( "cboxTest/testCrossValidation.2", "[unit]" )
-{
-	std::vector<unsigned char> pubk;
-	pubk.resize(mcleece_crypto_box_PUBLIC_KEY_SIZE);
-
-	std::vector<unsigned char> secret;
-	secret.resize(mcleece_crypto_box_SECRET_KEY_SIZE);
-
-	{
-		int res = mcleece_crypto_box_keypair(pubk.data(), secret.data());
-		assertEquals( 0, res );
-	}
-
-	string srcMessage = "hello friends";
-
-	string data = srcMessage;
-	data.resize(srcMessage.size() + mcleece_crypto_box_MESSAGE_HEADER_SIZE);
-	assertTrue( data.substr(0, 5) == "hello" );
-
-	{
-		std::vector<unsigned char> scratch;
-		scratch.resize(data.size() - mcleece_simple_MESSAGE_HEADER_SIZE);
-		int res = mcleece_inplace_crypto_box_seal(reinterpret_cast<unsigned char*>(data.data()), data.size(), scratch.data(), pubk.data());
-		assertEquals( 0, res );
-	}
-
-	// ciphertext is now in `data`
-
-	string dstMessage;
-	dstMessage.resize(srcMessage.size());
-	{
-		int res = mcleece_crypto_box_seal_open(reinterpret_cast<unsigned char*>(dstMessage.data()), reinterpret_cast<unsigned char*>(data.data()), data.size(), pubk.data(), secret.data());
-		assertEquals(0, res);
-	}
-
 	assertEquals( "hello friends", dstMessage );
 }

--- a/src/lib/mcleece/test/sodiumCryptoBoxTest.cpp
+++ b/src/lib/mcleece/test/sodiumCryptoBoxTest.cpp
@@ -69,3 +69,34 @@ TEST_CASE( "sodiumCryptoBoxTest/testCryptoBoxSealOpen", "[unit]" )
 
 	assertEquals( "hello friends", dstMessage );
 }
+
+TEST_CASE( "sodiumCryptoBoxTest/testCryptoBoxRoundtrip", "[unit]" )
+{
+	std::vector<unsigned char> pubk;
+	pubk.resize(crypto_box_publickeybytes());
+
+	std::vector<unsigned char> secret;
+	secret.resize(crypto_box_secretkeybytes());
+
+	{
+		int res = crypto_box_keypair(pubk.data(), secret.data());
+		assertEquals( 0, res );
+	}
+
+	string srcMessage = "hello friendos";
+	std::vector<unsigned char> cipherText;
+	cipherText.resize(srcMessage.size() + crypto_box_sealbytes());
+	{
+		int res = mcleece::sodium_crypto_box(pubk.data()).seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size());
+		assertEquals( 0, res );
+	}
+
+	string dstMessage;
+	dstMessage.resize(srcMessage.size());
+	{
+		int res = mcleece::sodium_crypto_box(pubk.data(), secret.data()).seal_open(reinterpret_cast<unsigned char*>(dstMessage.data()), cipherText.data(), cipherText.size());
+		assertEquals(0, res);
+	}
+
+	assertEquals( "hello friendos", dstMessage );
+}

--- a/src/lib/mcleece/test/sodiumCryptoBoxTest.cpp
+++ b/src/lib/mcleece/test/sodiumCryptoBoxTest.cpp
@@ -1,0 +1,71 @@
+/* This code is subject to the terms of the Mozilla Public License, v.2.0. http://mozilla.org/MPL/2.0/. */
+#include "unittest.h"
+
+#include "mcleece/sodium_crypto_box.h"
+
+#include <string>
+#include <vector>
+
+using std::string;
+
+TEST_CASE( "sodiumCryptoBoxTest/testCryptoBoxSeal", "[unit]" )
+{
+	std::vector<unsigned char> pubk;
+	pubk.resize(crypto_box_publickeybytes());
+
+	std::vector<unsigned char> secret;
+	secret.resize(crypto_box_secretkeybytes());
+
+	{
+		int res = crypto_box_keypair(pubk.data(), secret.data());
+		assertEquals( 0, res );
+	}
+
+	string srcMessage = "hello friends";
+	std::vector<unsigned char> cipherText;
+	cipherText.resize(srcMessage.size() + crypto_box_sealbytes());
+	{
+		int res = mcleece::sodium_crypto_box(pubk.data()).seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size());
+		assertEquals( 0, res );
+	}
+
+	string dstMessage;
+	dstMessage.resize(srcMessage.size());
+	{
+		int res = crypto_box_seal_open(reinterpret_cast<unsigned char*>(dstMessage.data()), cipherText.data(), cipherText.size(), pubk.data(), secret.data());
+		assertEquals(0, res);
+	}
+
+	assertEquals( "hello friends", dstMessage );
+}
+
+TEST_CASE( "sodiumCryptoBoxTest/testCryptoBoxSealOpen", "[unit]" )
+{
+	std::vector<unsigned char> pubk;
+	pubk.resize(crypto_box_publickeybytes());
+
+	std::vector<unsigned char> secret;
+	secret.resize(crypto_box_secretkeybytes());
+
+	{
+		int res = crypto_box_keypair(pubk.data(), secret.data());
+		assertEquals( 0, res );
+	}
+
+	string srcMessage = "hello friends";
+	std::vector<unsigned char> cipherText;
+	cipherText.resize(srcMessage.size() + crypto_box_sealbytes());
+	{
+		int res = crypto_box_seal(cipherText.data(), reinterpret_cast<unsigned char*>(srcMessage.data()), srcMessage.size(), pubk.data());
+		assertEquals( 0, res );
+	}
+
+	string dstMessage;
+	dstMessage.resize(srcMessage.size());
+	{
+		int res = mcleece::sodium_crypto_box(pubk.data(), secret.data()).seal_open(reinterpret_cast<unsigned char*>(dstMessage.data()), cipherText.data(), cipherText.size());
+		assertEquals(0, res);
+	}
+
+	assertEquals( "hello friends", dstMessage );
+}

--- a/src/lib/util/byte_view.h
+++ b/src/lib/util/byte_view.h
@@ -10,8 +10,12 @@ namespace mcleece {
 	{
 		using std::basic_string_view<unsigned char>::basic_string_view;
 
-		byte_view(char* data, size_t len)
+		byte_view(unsigned char* data, size_t len)
 			: std::basic_string_view<unsigned char>::basic_string_view(reinterpret_cast<unsigned char*>(data), len)
+		{}
+
+		byte_view(char* data, size_t len)
+			: mcleece::byte_view(reinterpret_cast<unsigned char*>(data), len)
 		{}
 
 		byte_view(const char* data, size_t len)


### PR DESCRIPTION
This eliminates the weird `inplace` apis in favor of an XOR merge of two 32-byte secrets (one using the `crypto_box_seal` x25519 algorithm, one using Classic McEliece KEM) as the key into libsodium `crypto_box`.

There will need to be some cleanup, but this feels like a clear improvement over the previous layered implementation.